### PR TITLE
Use node-swig/swig-templates fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "nodelint": "~0.6.2",
     "expect.js": "~0.2.0",
     "mocha": "~1.12.0",
-    "swig": ">=1"
+    "swig-templates": ">=2"
   },
   "dependencies": {
     "markdown": "~0.5.0"

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -1,4 +1,4 @@
-var swig = require('swig'),
+var swig = require('swig-templates'),
   expect = require('expect.js'),
   extras = require('../');
 

--- a/tests/tags.test.js
+++ b/tests/tags.test.js
@@ -1,4 +1,4 @@
-var swig = require('swig'),
+var swig = require('swig-templates'),
   expect = require('expect.js'),
   extras = require('../');
 


### PR DESCRIPTION
Guess we might as well use the new fork since it's in npm, right? :-)

(I know this module fork isn't itself published but hopefully one day might.)